### PR TITLE
Update Wagtail requirement and introduce a couple of accessibility errors in `base.html`

### DIFF
--- a/myblog/templates/base.html
+++ b/myblog/templates/base.html
@@ -1,5 +1,6 @@
 {% verbatim %}
 {% load static wagtailcore_tags wagtailuserbar %}
+{% wagtail_site as current_site %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -10,12 +11,11 @@
             {% if page.seo_title %}{{ page.seo_title }}{% else %}{{ page.title }}{% endif %}
             {% endblock %}
             {% block title_suffix %}
-            {% wagtail_site as current_site %}
             {% if current_site and current_site.site_name %}- {{ current_site.site_name }}{% endif %}
             {% endblock %}
         </title>
         {% if page.search_description %}
-        <meta name="description" content="{{ page.search_description }}" />
+            <meta name="description" content="{{ page.search_description }}" />
         {% endif %}
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -41,10 +41,16 @@
     <body class="{% block body_class %}{% endblock %}">
         {% wagtailuserbar %}
 
-        {# Wrap your block content  within a <main> HTML5 tag: #}
-            <main>
-                {% block content %}{% endblock %}
-            </main>
+        <div class="header">
+            My Wagtail Blog
+        </div>
+
+        {% block content %}{% endblock %}
+
+        <footer>
+            <h2>{{ current_site.site_name }}</h2>
+            © 2024 Firstname Lastname
+        </footer>
 
         {# Global javascript #}
         <script type="text/javascript" src="{% static 'js/myblog.js' %}"></script>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Django>=4.2,<5.1
-wagtail==6.1a0
+wagtail>=6.1,<7


### PR DESCRIPTION
The changes in `base.html` are there to support the initial demonstration of the accessibility checker, causing errors for content not contained within landmarks.